### PR TITLE
Python 3 support

### DIFF
--- a/build.py
+++ b/build.py
@@ -29,7 +29,7 @@ class MDPreprocessor():
             self.md += line
 
     def render(self):
-        self.md = base64.b64encode(self.md)
+        self.md = base64.b64encode(self.md.encode('utf-8')).decode('utf-8')
         return {'md' : self.md, 'tags' : self.tags, 'date' : self.date}
 
     def json(self):


### PR DESCRIPTION
Fix `TypeError: a bytes-like object is required, not 'str'` when running in Python 3